### PR TITLE
Add cache deny list logic

### DIFF
--- a/components/jms-mq-support/org.wso2.carbon.cache.sync.jms.manager/pom.xml
+++ b/components/jms-mq-support/org.wso2.carbon.cache.sync.jms.manager/pom.xml
@@ -39,11 +39,6 @@
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon</groupId>
-            <artifactId>org.wso2.carbon.user.core</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.wso2.carbon</groupId>
             <artifactId>javax.cache.wso2</artifactId>
             <scope>provided</scope>
         </dependency>
@@ -114,7 +109,6 @@
                             org.wso2.carbon.caching.impl;version="${carbon.kernel.imp.pkg.version.range}",
                             org.wso2.carbon.caching.impl.clustering;version="${carbon.kernel.imp.pkg.version.range}",
                             org.wso2.carbon.context;version="${carbon.kernel.imp.pkg.version.range}",
-                            org.wso2.carbon.user.core.service;version="${carbon.kernel.imp.pkg.version.range}",
                             org.wso2.carbon.identity.core.util;
                             version="${carbon.identity.framework.imp.pkg.version.range}",
                         </Import-Package>

--- a/components/jms-mq-support/org.wso2.carbon.cache.sync.jms.manager/src/main/java/org/wso2/carbon/cache/sync/jms/manager/JMSProducer.java
+++ b/components/jms-mq-support/org.wso2.carbon.cache.sync.jms.manager/src/main/java/org/wso2/carbon/cache/sync/jms/manager/JMSProducer.java
@@ -133,18 +133,18 @@ public class JMSProducer implements CacheEntryRemovedListener, CacheEntryUpdated
             return;
         }
 
-        if (log.isDebugEnabled()) {
-            log.debug("Sending cache invalidation message to other cluster nodes for '" +
-                    cacheEntryInfo.getCacheKey() + "' of the cache '" + cacheEntryInfo.getCacheName()
-                    + "' of the cache manager '" + cacheEntryInfo.getCacheManagerName() + "'");
-        }
-
         if (!isAllowedToPropagate(cacheEntryInfo.getCacheManagerName(), cacheEntryInfo.getCacheName())) {
             if (log.isDebugEnabled()) {
                 log.debug("Cache " + cacheEntryInfo.getCacheKey() + " is not allowed to propagate to " +
                         "other clusters as per configurations.");
             }
             return;
+        }
+
+        if (log.isDebugEnabled()) {
+            log.debug("Sending cache invalidation message to other cluster nodes for '" +
+                    cacheEntryInfo.getCacheKey() + "' of the cache '" + cacheEntryInfo.getCacheName()
+                    + "' of the cache manager '" + cacheEntryInfo.getCacheManagerName() + "'");
         }
 
         // Send the cluster message.

--- a/components/jms-mq-support/org.wso2.carbon.cache.sync.jms.manager/src/main/java/org/wso2/carbon/cache/sync/jms/manager/JMSProducer.java
+++ b/components/jms-mq-support/org.wso2.carbon.cache.sync.jms.manager/src/main/java/org/wso2/carbon/cache/sync/jms/manager/JMSProducer.java
@@ -50,6 +50,7 @@ import javax.naming.InitialContext;
 import javax.naming.NamingException;
 
 import static org.wso2.carbon.cache.sync.jms.manager.JMSUtils.PRODUCER_RETRY_LIMIT;
+import static org.wso2.carbon.cache.sync.jms.manager.JMSUtils.isAllowedToPropagate;
 
 /**
  * This class contains the logic for sending cache invalidation message.
@@ -136,6 +137,14 @@ public class JMSProducer implements CacheEntryRemovedListener, CacheEntryUpdated
             log.debug("Sending cache invalidation message to other cluster nodes for '" +
                     cacheEntryInfo.getCacheKey() + "' of the cache '" + cacheEntryInfo.getCacheName()
                     + "' of the cache manager '" + cacheEntryInfo.getCacheManagerName() + "'");
+        }
+
+        if (!isAllowedToPropagate(cacheEntryInfo.getCacheManagerName(), cacheEntryInfo.getCacheName())) {
+            if (log.isDebugEnabled()) {
+                log.debug("Cache " + cacheEntryInfo.getCacheKey() + " is not allowed to propagate to " +
+                        "other clusters as per configurations.");
+            }
+            return;
         }
 
         // Send the cluster message.

--- a/components/jms-mq-support/org.wso2.carbon.cache.sync.jms.manager/src/main/java/org/wso2/carbon/cache/sync/jms/manager/JMSUtils.java
+++ b/components/jms-mq-support/org.wso2.carbon.cache.sync.jms.manager/src/main/java/org/wso2/carbon/cache/sync/jms/manager/JMSUtils.java
@@ -20,6 +20,8 @@ package org.wso2.carbon.cache.sync.jms.manager;
 import com.rabbitmq.jms.admin.RMQConnectionFactory;
 import org.apache.axiom.om.OMElement;
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.base.IdentityConstants;
 import org.wso2.carbon.identity.base.IdentityRuntimeException;
 import org.wso2.carbon.identity.core.util.IdentityConfigParser;
@@ -50,6 +52,7 @@ import javax.xml.namespace.QName;
  */
 public class JMSUtils {
 
+    private static final Log log = LogFactory.getLog(JMSUtils.class);
     public static final String MB_TYPE = "CacheInvalidator.MB.Type";
     public static final String INVALIDATOR_ENABLED_PROPERTY = "CacheInvalidator.MB.Enabled";
     public static final String RUN_IN_HYBRID_MODE_PROPERTY = "CacheInvalidator.MB.HybridMode";
@@ -268,7 +271,8 @@ public class JMSUtils {
                     String cacheManagerName = cacheManager.getAttributeValue(new QName(
                             IdentityConstants.CACHE_MANAGER_NAME));
                     if (StringUtils.isBlank(cacheManagerName)) {
-                        throw IdentityRuntimeException.error("CacheManager name not defined correctly");
+                        log.warn("CacheManager name not defined correctly");
+                        continue;
                     }
                     Iterator<OMElement> caches = cacheManager.getChildrenWithName(
                             new QName(IdentityCoreConstants.IDENTITY_DEFAULT_NAMESPACE, IdentityConstants.CACHE));
@@ -278,7 +282,8 @@ public class JMSUtils {
                             OMElement cache = caches.next();
                             String cacheName = cache.getAttributeValue(new QName(IdentityConstants.CACHE_NAME));
                             if (StringUtils.isBlank(cacheName)) {
-                                throw IdentityRuntimeException.error("Cache name not defined correctly");
+                                log.warn("Cache name not defined correctly");
+                                continue;
                             }
                             cacheNames.add(cacheName);
                         }

--- a/components/jms-mq-support/org.wso2.carbon.cache.sync.jms.manager/src/main/java/org/wso2/carbon/cache/sync/jms/manager/JMSUtils.java
+++ b/components/jms-mq-support/org.wso2.carbon.cache.sync.jms.manager/src/main/java/org/wso2/carbon/cache/sync/jms/manager/JMSUtils.java
@@ -18,10 +18,20 @@
 package org.wso2.carbon.cache.sync.jms.manager;
 
 import com.rabbitmq.jms.admin.RMQConnectionFactory;
+import org.apache.axiom.om.OMElement;
 import org.apache.commons.lang.StringUtils;
+import org.wso2.carbon.identity.base.IdentityConstants;
+import org.wso2.carbon.identity.base.IdentityRuntimeException;
+import org.wso2.carbon.identity.core.util.IdentityConfigParser;
+import org.wso2.carbon.identity.core.util.IdentityCoreConstants;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.function.BiFunction;
 import java.util.function.UnaryOperator;
@@ -33,6 +43,7 @@ import javax.jms.Session;
 import javax.jms.Topic;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
+import javax.xml.namespace.QName;
 
 /**
  * Util class for the JMS cache manager Service.
@@ -62,6 +73,10 @@ public class JMSUtils {
     public static final String BROKER_TYPE_JMS = "jms";
     public static final String LOOKUP_CONNECTION_FACTORY = "ConnectionFactory";
     public static final String LOOKUP_TOPIC = "exampleTopic";
+    public static final String CACHE_INVALIDATOR_ELEMENT = "CacheInvalidator";
+    public static final String CACHE_MANAGER_ELEMENT = "CacheManager";
+
+    private static Map<String, List<String>> mbCacheListConfigurationHolder;
 
     private JMSUtils() {
 
@@ -191,10 +206,87 @@ public class JMSUtils {
         return session.createTopic(getConfiguredStringValue.apply(JNDI_TOPIC_PROP_NAME_VALUE));
     }
 
+    /**
+     * Check the cache in the denylist before sync across clusters.
+     *
+     * @param cacheManager cacheManager name
+     * @param cacheName cacheName
+     * @return whether the cache is allowed or not.
+     */
+    public static boolean isAllowedToPropagate(String cacheManager, String cacheName) {
+
+        Map<String, List<String>> cacheDenyList = getMessageBrokerCacheList();
+        if (cacheDenyList.size() == 0) {
+            return true;
+        }
+        String cache = getCacheName(cacheName);
+        for (Map.Entry<String, List<String>> entry : cacheDenyList.entrySet()) {
+            if (StringUtils.equalsIgnoreCase(cacheManager, entry.getKey())) {
+                if (entry.getValue().contains(cache)) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+
+    private static Map<String, List<String>> getMessageBrokerCacheList() {
+
+        if (mbCacheListConfigurationHolder == null) {
+            buildMBCacheListConfig();
+        }
+        return mbCacheListConfigurationHolder;
+    }
+
     private static ConnectionFactory createRabbitMQConnectionFactory() throws JMSException {
 
         RMQConnectionFactory factory = new RMQConnectionFactory();
         factory.setUri(getConfiguredStringValue.apply(JNDI_PROVIDER_URL_PROP_VALUE));
         return factory;
+    }
+
+    private static String getCacheName(String cacheName) {
+
+        // Cache names are by default prefixed with "$__local__$." or "$__clear__all__$."
+        String[] cacheNameParts = cacheName.split("\\.");
+        if (cacheNameParts.length >= 2) {
+            return cacheNameParts[1];
+        }
+        return null;
+    }
+
+    private static void buildMBCacheListConfig() {
+
+        mbCacheListConfigurationHolder = new HashMap<>();
+        OMElement cacheConfig = IdentityConfigParser.getInstance().getConfigElement(CACHE_INVALIDATOR_ELEMENT);
+        if (cacheConfig != null) {
+            Iterator<OMElement> cacheManagers = cacheConfig.getChildrenWithName(
+                    new QName(IdentityCoreConstants.IDENTITY_DEFAULT_NAMESPACE, CACHE_MANAGER_ELEMENT));
+            if (cacheManagers != null) {
+                while (cacheManagers.hasNext()) {
+                    OMElement cacheManager = cacheManagers.next();
+                    String cacheManagerName = cacheManager.getAttributeValue(new QName(
+                            IdentityConstants.CACHE_MANAGER_NAME));
+                    if (StringUtils.isBlank(cacheManagerName)) {
+                        throw IdentityRuntimeException.error("CacheManager name not defined correctly");
+                    }
+                    Iterator<OMElement> caches = cacheManager.getChildrenWithName(
+                            new QName(IdentityCoreConstants.IDENTITY_DEFAULT_NAMESPACE, IdentityConstants.CACHE));
+                    List<String> cacheNames = new ArrayList<>();
+                    if (caches != null) {
+                        while (caches.hasNext()) {
+                            OMElement cache = caches.next();
+                            String cacheName = cache.getAttributeValue(new QName(IdentityConstants.CACHE_NAME));
+                            if (StringUtils.isBlank(cacheName)) {
+                                throw IdentityRuntimeException.error("Cache name not defined correctly");
+                            }
+                            cacheNames.add(cacheName);
+                        }
+                    }
+                    mbCacheListConfigurationHolder.put(cacheManagerName, cacheNames);
+                }
+            }
+        }
     }
 }

--- a/components/jms-mq-support/org.wso2.carbon.cache.sync.jms.manager/src/main/java/org/wso2/carbon/cache/sync/jms/manager/JMSUtils.java
+++ b/components/jms-mq-support/org.wso2.carbon.cache.sync.jms.manager/src/main/java/org/wso2/carbon/cache/sync/jms/manager/JMSUtils.java
@@ -230,7 +230,6 @@ public class JMSUtils {
         return true;
     }
 
-
     private static Map<String, List<String>> getMessageBrokerCacheList() {
 
         if (mbCacheListConfigurationHolder == null) {

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,29 @@
         </snapshotRepository>
     </distributionManagement>
 
+    <repositories>
+        <repository>
+            <id>wso2-ss-nexus</id>
+            <name>WSO2 internal Repository</name>
+            <url>https://support-maven.wso2.org/nexus/content/repositories/releases/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+                <checksumPolicy>ignore</checksumPolicy>
+            </releases>
+        </repository>
+
+        <repository>
+            <id>wso2-s-nexus</id>
+            <name>Support Nexus Repository of WSO2</name>
+            <url>https://support-maven.wso2.org/nexus/content/repositories/updates-2.0/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+                <checksumPolicy>ignore</checksumPolicy>
+            </releases>
+        </repository>
+    </repositories>
     <modules>
         <module>components/jms-mq-support</module>
     </modules>
@@ -80,11 +103,6 @@
                 <groupId>org.apache.felix</groupId>
                 <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
                 <version>${org.apache.felix.scr.ds-annotations.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.wso2.carbon</groupId>
-                <artifactId>org.wso2.carbon.user.core</artifactId>
-                <version>${org.wso2.carbon.user.core.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.identity.framework</groupId>
@@ -273,7 +291,6 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <org.apache.felix.scr.ds-annotations.version>1.2.10</org.apache.felix.scr.ds-annotations.version>
-        <org.wso2.carbon.user.core.version>4.7.0-beta2</org.wso2.carbon.user.core.version>
         <carbon.identity.framework.version>5.18.187</carbon.identity.framework.version>
         <log4j-api.version>2.14.1</log4j-api.version>
         <carbon.p2.plugin.version>5.1.2</carbon.p2.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -70,29 +70,6 @@
         </snapshotRepository>
     </distributionManagement>
 
-    <repositories>
-        <repository>
-            <id>wso2-ss-nexus</id>
-            <name>WSO2 internal Repository</name>
-            <url>https://support-maven.wso2.org/nexus/content/repositories/releases/</url>
-            <releases>
-                <enabled>true</enabled>
-                <updatePolicy>daily</updatePolicy>
-                <checksumPolicy>ignore</checksumPolicy>
-            </releases>
-        </repository>
-
-        <repository>
-            <id>wso2-s-nexus</id>
-            <name>Support Nexus Repository of WSO2</name>
-            <url>https://support-maven.wso2.org/nexus/content/repositories/updates-2.0/</url>
-            <releases>
-                <enabled>true</enabled>
-                <updatePolicy>daily</updatePolicy>
-                <checksumPolicy>ignore</checksumPolicy>
-            </releases>
-        </repository>
-    </repositories>
     <modules>
         <module>components/jms-mq-support</module>
     </modules>


### PR DESCRIPTION
## Purpose
> This will introduce the list of caches that do not need to be synced with other clusters. This will reduce the amount of invalidation messages.

Following is the deployment.toml config
```
[[cache_invalidator.sync_block_list.cache_manager]]
name="xxxCacheManager"
list=["xxxCache","zzzCache"]
```
eg:
```
[[cache_invalidator.sync_block_list.cache_manager]]
name="IdentityApplicationManagementCacheManager"
list=["AuthenticationResultCache","AuthenticationRequestCache"]

[[cache_invalidator.sync_block_list.cache_manager]]
name="AUTHORIZATION_CACHE_MANAGER"
list=["AUTHORIZATION_CACHE"]
```

improvement needed for `identity.xml.j2`

```
 <CacheInvalidator>
       ...
     {% for cache_manager in cache_invalidator.sync_block_list.cache_manager %}
     <CacheManager name="{{cache_manager.name}}">
          {% for cache_name in cache_manager.list %}
         <Cache name="{{cache_name}}"/>
          {% endfor %}
     </CacheManager>
     {% endfor %}
</CacheInvalidator>
```

## Related PRs
- public https://github.com/wso2/carbon-identity-framework/pull/5407
- support https://github.com/wso2-support/product-is/pull/1322

