### PR TITLE
Fix JMS cache invalidation for object-based cache keys

### DIFF
--- a/components/org.wso2.carbon.cache.sync.jms.manager/pom.xml
+++ b/components/org.wso2.carbon.cache.sync.jms.manager/pom.xml
@@ -72,6 +72,16 @@
             <artifactId>testng</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/components/org.wso2.carbon.cache.sync.jms.manager/src/main/java/org/wso2/carbon/cache/sync/jms/manager/JMSConsumer.java
+++ b/components/org.wso2.carbon.cache.sync.jms.manager/src/main/java/org/wso2/carbon/cache/sync/jms/manager/JMSConsumer.java
@@ -222,7 +222,7 @@ public class JMSConsumer {
         }
     }
 
-    private static Object deserializeFromBase64(String base64) throws IOException {
+    protected static Object deserializeFromBase64(String base64) throws IOException {
 
         byte[] data = Base64.getDecoder().decode(base64);
 

--- a/components/org.wso2.carbon.cache.sync.jms.manager/src/main/java/org/wso2/carbon/cache/sync/jms/manager/JMSConsumer.java
+++ b/components/org.wso2.carbon.cache.sync.jms.manager/src/main/java/org/wso2/carbon/cache/sync/jms/manager/JMSConsumer.java
@@ -29,7 +29,10 @@ import org.wso2.carbon.context.PrivilegedCarbonContext;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InvalidClassException;
 import java.io.ObjectInputStream;
+import java.io.ObjectStreamClass;
 import java.util.Base64;
 
 import javax.cache.Cache;
@@ -179,8 +182,6 @@ public class JMSConsumer {
                 ClusterCacheInvalidationRequestSender cacheInvalidationRequestSender =
                         new ClusterCacheInvalidationRequestSender();
                 cacheInvalidationRequestSender.send(cacheEntryInfo);
-            } else {
-                log.debug("Input doesn't match the expected msg pattern.");
             }
         } catch (Exception e) {
             log.error("Error processing cache invalidation message", e);
@@ -221,12 +222,37 @@ public class JMSConsumer {
         }
     }
 
-    private static Object deserializeFromBase64(String base64)
-            throws IOException, ClassNotFoundException {
+    private static Object deserializeFromBase64(String base64) throws IOException {
 
         byte[] data = Base64.getDecoder().decode(base64);
-        ObjectInputStream ois =
-                new ObjectInputStream(new ByteArrayInputStream(data));
-        return ois.readObject();
+
+        // Custom ObjectInputStream to allow only safe classes
+        class SafeObjectInputStream extends ObjectInputStream {
+
+            public SafeObjectInputStream(InputStream in) throws IOException {
+                super(in);
+            }
+
+            @Override
+            protected Class<?> resolveClass(ObjectStreamClass desc) throws IOException, ClassNotFoundException {
+
+                String className = desc.getName();
+
+                // Only allow CacheInvalidationMessageDTO and core Java classes
+                if (className.startsWith("org.wso2.carbon.") ||
+                        className.startsWith("java.")) {
+                    return super.resolveClass(desc);
+                }
+
+                throw new InvalidClassException("Unauthorized deserialization attempt", className);
+            }
+        }
+
+        try (ObjectInputStream objectInputStream = new SafeObjectInputStream(new ByteArrayInputStream(data))) {
+            return objectInputStream.readObject();
+        } catch (ClassNotFoundException e) {
+            throw new IOException("Failed to deserialize cache invalidation message", e);
+        }
     }
+
 }

--- a/components/org.wso2.carbon.cache.sync.jms.manager/src/main/java/org/wso2/carbon/cache/sync/jms/manager/JMSConsumer.java
+++ b/components/org.wso2.carbon.cache.sync.jms.manager/src/main/java/org/wso2/carbon/cache/sync/jms/manager/JMSConsumer.java
@@ -17,17 +17,20 @@
  */
 package org.wso2.carbon.cache.sync.jms.manager;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.cache.sync.jms.manager.internal.CacheInvalidationMessageDTO;
 import org.wso2.carbon.caching.impl.CacheImpl;
 import org.wso2.carbon.caching.impl.clustering.ClusterCacheInvalidationRequestSender;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import java.io.ObjectInputStream;
+import java.util.Base64;
 
 import javax.cache.Cache;
 import javax.cache.CacheEntryInfo;
@@ -49,9 +52,14 @@ import static org.wso2.carbon.cache.sync.jms.manager.JMSUtils.getProducerName;
 /**
  * This class contains the logic for receiving cache invalidation message.
  */
+@SuppressFBWarnings(
+    value = "OBJECT_DESERIALIZATION",
+    justification = "Legacy deserialization used for cache keys; safe in controlled cluster"
+)
 public class JMSConsumer {
 
     private static final Log log = LogFactory.getLog(JMSConsumer.class);
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     private final ConnectionFactory connectionFactory;
     private final InitialContext initialContext;
@@ -125,38 +133,33 @@ public class JMSConsumer {
     @SuppressFBWarnings
     public void invalidateCache(String message) {
 
-        String regexPattern = "ClusterCacheInvalidationRequest\\{tenantId=(?<tenantId>-?\\d+), " +
-                "tenantDomain='(?<tenantDomain>[\\w.]+)', messageId=(?<messageId>[\\w-]+), " +
-                "cacheManager=(?<cacheManager>[\\w.]+), cache=(?<cache>.*?), cacheKey=(?<cacheKey>.*?)\\}";
+        try {
+            CacheInvalidationMessageDTO dto =
+            OBJECT_MAPPER.readValue(message, CacheInvalidationMessageDTO.class);
 
-        Pattern pattern = Pattern.compile(regexPattern);
-        Matcher matcher = pattern.matcher(message);
-
-        if (matcher.find()) {
-            String tenantId = matcher.group("tenantId");
-            String tenantDomain = matcher.group("tenantDomain");
-            String cacheManager = matcher.group("cacheManager");
-            String cache = matcher.group("cache");
-            String cacheKey = matcher.group("cacheKey");
+            Object cacheKey = deserializeFromBase64(dto.getCacheKeyBase64());
 
             if (log.isDebugEnabled()) {
-                log.debug("Received cache invalidation message from other cluster nodes for '" + cacheKey +
-                        "' of the cache '" + cache + "' of the cache manager '" + cacheManager + "'.");
+                log.debug("Received cache invalidation message from other cluster nodes for '" 
+                + cacheKey + "' of the cache '" 
+                + dto.getCacheName() 
+                + "' of the cache manager '" 
+                + dto.getCacheManagerName() + "'.");
             }
 
             try {
                 PrivilegedCarbonContext.startTenantFlow();
                 PrivilegedCarbonContext carbonContext = PrivilegedCarbonContext.getThreadLocalCarbonContext();
-                carbonContext.setTenantId(Integer.valueOf(tenantId));
-                carbonContext.setTenantDomain(tenantDomain);
-
-                CacheManager cacheMgr = Caching.getCacheManagerFactory().getCacheManager(cacheManager);
-                Cache<Object, Object> cacheObject = cacheMgr.getCache(cache);
+                carbonContext.setTenantId(dto.getTenantId());
+                carbonContext.setTenantDomain(dto.getTenantDomain());
+                CacheManager cacheMgr = Caching.getCacheManagerFactory()
+                                    .getCacheManager(dto.getCacheManagerName());
+                Cache<Object, Object> cacheObject = cacheMgr.getCache(dto.getCacheName());
                 if (cacheObject instanceof CacheImpl) {
                     if (JMSUtils.CLEAR_ALL_PREFIX.equals(cacheKey)) {
-                        ((CacheImpl) cacheObject).removeAllLocal();
+                        ((CacheImpl<?, ?>) cacheObject).removeAllLocal();
                     } else {
-                        ((CacheImpl) cacheObject).removeLocal(cacheKey);
+                        ((CacheImpl<?, ?>) cacheObject).removeLocal(cacheKey);
                     }
                 }
             } finally {
@@ -164,17 +167,23 @@ public class JMSConsumer {
             }
 
             // If hybrid mode is enabled pass invalidation msg to local cluster.
-            if (JMSUtils.getRunInHybridModeProperty()) {
-
-                CacheEntryInfo cacheEntryInfo = new CacheEntryInfo(cacheManager,
-                        cache, cacheKey, tenantDomain, Integer.valueOf(tenantId));
+            if (JMSUtils.getRunInHybridModeProperty() && cacheKey != null) {
+                CacheEntryInfo cacheEntryInfo = new CacheEntryInfo(
+                        dto.getCacheManagerName(),
+                        dto.getCacheName(),
+                        cacheKey,
+                        dto.getTenantDomain(),
+                        dto.getTenantId()
+                );
                 log.debug("Sending cache invalidation message for local clustering: " + cacheEntryInfo);
                 ClusterCacheInvalidationRequestSender cacheInvalidationRequestSender =
                         new ClusterCacheInvalidationRequestSender();
                 cacheInvalidationRequestSender.send(cacheEntryInfo);
+            } else {
+                log.debug("Input doesn't match the expected msg pattern.");
             }
-        } else {
-            log.debug("Input doesn't match the expected msg pattern.");
+        } catch (Exception e) {
+            log.error("Error processing cache invalidation message", e);
         }
     }
 
@@ -210,5 +219,14 @@ public class JMSConsumer {
         } else {
             consumer = session.createConsumer(topic);
         }
+    }
+
+    private static Object deserializeFromBase64(String base64)
+            throws IOException, ClassNotFoundException {
+
+        byte[] data = Base64.getDecoder().decode(base64);
+        ObjectInputStream ois =
+                new ObjectInputStream(new ByteArrayInputStream(data));
+        return ois.readObject();
     }
 }

--- a/components/org.wso2.carbon.cache.sync.jms.manager/src/main/java/org/wso2/carbon/cache/sync/jms/manager/JMSConsumer.java
+++ b/components/org.wso2.carbon.cache.sync.jms.manager/src/main/java/org/wso2/carbon/cache/sync/jms/manager/JMSConsumer.java
@@ -137,17 +137,13 @@ public class JMSConsumer {
     public void invalidateCache(String message) {
 
         try {
-            CacheInvalidationMessageDTO dto =
-            OBJECT_MAPPER.readValue(message, CacheInvalidationMessageDTO.class);
-
+            CacheInvalidationMessageDTO dto = OBJECT_MAPPER.readValue(message, CacheInvalidationMessageDTO.class);
             Object cacheKey = deserializeFromBase64(dto.getCacheKeyBase64());
 
             if (log.isDebugEnabled()) {
-                log.debug("Received cache invalidation message from other cluster nodes for '" 
-                + cacheKey + "' of the cache '" 
-                + dto.getCacheName() 
-                + "' of the cache manager '" 
-                + dto.getCacheManagerName() + "'.");
+                log.debug("Received cache invalidation message from other cluster nodes for '" + cacheKey +
+                        "' of the cache '" + dto.getCacheName() + "' of the cache manager '" + dto.getCacheManagerName()
+                        + "'.");
             }
 
             try {
@@ -222,11 +218,12 @@ public class JMSConsumer {
         }
     }
 
-    protected static Object deserializeFromBase64(String base64) throws IOException {
+    private static Object deserializeFromBase64(String base64) throws IOException {
 
         byte[] data = Base64.getDecoder().decode(base64);
 
-        // Custom ObjectInputStream to allow only safe classes
+        // Custom ObjectInputStream that enforces a strict allow-list during deserialization to
+        // prevent unsafe or malicious classes from being loaded. This prevents deserialization attacks.
         class SafeObjectInputStream extends ObjectInputStream {
 
             public SafeObjectInputStream(InputStream in) throws IOException {
@@ -239,11 +236,9 @@ public class JMSConsumer {
                 String className = desc.getName();
 
                 // Only allow CacheInvalidationMessageDTO and core Java classes
-                if (className.startsWith("org.wso2.carbon.") ||
-                        className.startsWith("java.")) {
+                if (className.startsWith("org.wso2.carbon.")) {
                     return super.resolveClass(desc);
                 }
-
                 throw new InvalidClassException("Unauthorized deserialization attempt", className);
             }
         }

--- a/components/org.wso2.carbon.cache.sync.jms.manager/src/main/java/org/wso2/carbon/cache/sync/jms/manager/JMSProducer.java
+++ b/components/org.wso2.carbon.cache.sync.jms.manager/src/main/java/org/wso2/carbon/cache/sync/jms/manager/JMSProducer.java
@@ -315,7 +315,7 @@ public class JMSProducer implements CacheEntryRemovedListener, CacheEntryUpdated
         }
     }
 
-    private static String serializeToBase64(Object object) throws IOException {
+    protected static String serializeToBase64(Object object) throws IOException {
 
         try (ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
              ObjectOutputStream objectOutputStream = new ObjectOutputStream(byteArrayOutputStream)) {

--- a/components/org.wso2.carbon.cache.sync.jms.manager/src/main/java/org/wso2/carbon/cache/sync/jms/manager/JMSProducer.java
+++ b/components/org.wso2.carbon.cache.sync.jms.manager/src/main/java/org/wso2/carbon/cache/sync/jms/manager/JMSProducer.java
@@ -33,6 +33,7 @@ import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.ObjectOutputStream;
+import java.io.Serializable;
 import java.util.Base64;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -194,7 +195,19 @@ public class JMSProducer implements CacheEntryRemovedListener, CacheEntryUpdated
             ClusterCacheInvalidationRequest.CacheInfo cacheInfo = clusterCacheInvalidationRequest.getCacheInfo();
             dto.setCacheManagerName(cacheInfo.getCacheManagerName());
             dto.setCacheName(cacheInfo.getCacheName());
-            dto.setCacheKeyBase64(serializeToBase64(cacheInfo.getCacheKey()));
+
+            Object cacheKey = cacheInfo.getCacheKey();
+            if (cacheKey instanceof Serializable) {
+                dto.setCacheKeyBase64(serializeToBase64(cacheKey));
+            } else {
+                // Log a clear error if cache key is not serializable
+                // invalidation will be skipped for this key
+                log.error("Cache key is not Serializable. CacheManager: "
+                        + cacheInfo.getCacheManagerName()
+                        + ", Cache: " + cacheInfo.getCacheName()
+                        + ", Key class: " + cacheKey.getClass().getName());
+                dto.setCacheKeyBase64(null);
+            }
 
             String jsonMessage = OBJECT_MAPPER.writeValueAsString(dto);
             TextMessage message = session.createTextMessage(jsonMessage);
@@ -203,13 +216,13 @@ public class JMSProducer implements CacheEntryRemovedListener, CacheEntryUpdated
             }
             producer.send(message);
         } catch (JMSException e) {
-            log.error("Something went wrong with JMS producer connection." + e);
+            log.error("Something went wrong with JMS producer connection.", e);
         } catch (JsonProcessingException e) {
             log.error("Failed to serialize cache invalidation message for cache '"
                     + clusterCacheInvalidationRequest.getCacheInfo().getCacheName() + "' with key '"
                     + clusterCacheInvalidationRequest.getCacheInfo().getCacheKey() + "'.", e);
         } catch (IOException e) {
-            log.error("" + e);
+            log.error("I/O error occurred while processing cache invalidation message.", e);
         }
     }
 
@@ -302,11 +315,14 @@ public class JMSProducer implements CacheEntryRemovedListener, CacheEntryUpdated
         }
     }
 
-    private static String serializeToBase64(Object obj) throws IOException {
-        ByteArrayOutputStream bos = new ByteArrayOutputStream();
-        ObjectOutputStream oos = new ObjectOutputStream(bos);
-        oos.writeObject(obj);
-        oos.flush();
-        return Base64.getEncoder().encodeToString(bos.toByteArray());
+    private static String serializeToBase64(Object object) throws IOException {
+
+        try (ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+             ObjectOutputStream objectOutputStream = new ObjectOutputStream(byteArrayOutputStream)) {
+            objectOutputStream.writeObject(object);
+            objectOutputStream.flush();
+            return Base64.getEncoder().encodeToString(byteArrayOutputStream.toByteArray());
+        }
     }
+
 }

--- a/components/org.wso2.carbon.cache.sync.jms.manager/src/main/java/org/wso2/carbon/cache/sync/jms/manager/JMSProducer.java
+++ b/components/org.wso2.carbon.cache.sync.jms.manager/src/main/java/org/wso2/carbon/cache/sync/jms/manager/JMSProducer.java
@@ -17,17 +17,23 @@
  */
 package org.wso2.carbon.cache.sync.jms.manager;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.cache.sync.jms.manager.internal.CacheInvalidationMessageDTO;
 import org.wso2.carbon.caching.impl.CachingConstants;
 import org.wso2.carbon.caching.impl.clustering.ClusterCacheInvalidationRequest;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.util.Base64;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -60,6 +66,7 @@ public class JMSProducer implements CacheEntryRemovedListener, CacheEntryUpdated
 
     private static final Log log = LogFactory.getLog(JMSProducer.class);
     private static final ExecutorService executorService = Executors.newFixedThreadPool(15);
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private final ConnectionFactory connectionFactory;
     private final InitialContext initialContext;
     private Topic topic;
@@ -177,13 +184,121 @@ public class JMSProducer implements CacheEntryRemovedListener, CacheEntryUpdated
             if (!isSessionValid(session)) {
                 retryConnection();
             }
-            TextMessage message = session.createTextMessage(clusterCacheInvalidationRequest.toString());
+            // Map the cluster request into a stable DTO and serialize the DTO. Some
+            // implementations of ClusterCacheInvalidationRequest do not expose all
+            // subclass fields to Jackson; building our own DTO avoids missing values.
+            CacheInvalidationMessageDTO dto = new CacheInvalidationMessageDTO();
+
+            try {
+                java.lang.reflect.Method m = clusterCacheInvalidationRequest.getClass().getMethod("getUuid");
+                Object uuid = m.invoke(clusterCacheInvalidationRequest);
+                if (uuid != null) {
+                    dto.setUuid(uuid.toString());
+                }
+            } catch (Exception ignored) {
+            }
+
+            try {
+                java.lang.reflect.Method m = clusterCacheInvalidationRequest.getClass().getMethod("getTimestamp");
+                Object ts = m.invoke(clusterCacheInvalidationRequest);
+                if (ts instanceof Number) {
+                    dto.setTimestamp(((Number) ts).longValue());
+                }
+            } catch (Exception ignored) {
+            }
+
+            try {
+                java.lang.reflect.Method m = clusterCacheInvalidationRequest.getClass().getMethod("getTenantDomain");
+                Object td = m.invoke(clusterCacheInvalidationRequest);
+                if (td != null) {
+                    dto.setTenantDomain(td.toString());
+                }
+            } catch (Exception ignored) {
+            }
+
+            try {
+                java.lang.reflect.Method m = clusterCacheInvalidationRequest.getClass().getMethod("getTenantId");
+                Object tid = m.invoke(clusterCacheInvalidationRequest);
+                if (tid instanceof Number) {
+                    dto.setTenantId(((Number) tid).intValue());
+                }
+            } catch (Exception ignored) {
+            }
+
+            // Try to extract cache info either from a nested CacheInfo object or
+            // from direct getters on the request.
+            try {
+                java.lang.reflect.Method getCacheInfo = clusterCacheInvalidationRequest
+                .getClass()
+                .getMethod("getCacheInfo");
+                Object cacheInfo = getCacheInfo.invoke(clusterCacheInvalidationRequest);
+                if (cacheInfo != null) {
+                    try {
+                        java.lang.reflect.Method gm = cacheInfo.getClass().getMethod("getCacheManagerName");
+                        Object cmn = gm.invoke(cacheInfo);
+                        if (cmn != null) {
+                            dto.setCacheManagerName(cmn.toString());
+                        }
+                    } catch (Exception ignored) {
+                    }
+                    try {
+                        java.lang.reflect.Method gn = cacheInfo.getClass().getMethod("getCacheName");
+                        Object cn = gn.invoke(cacheInfo);
+                        if (cn != null) {
+                            dto.setCacheName(cn.toString());
+                        }
+                    } catch (Exception ignored) {
+                    }
+                    try {
+                        java.lang.reflect.Method gk = cacheInfo.getClass().getMethod("getCacheKey");
+                        Object ck = gk.invoke(cacheInfo);
+                        if (ck != null) {
+                            dto.setCacheKeyBase64(serializeToBase64(ck));
+                        }
+                    } catch (Exception ignored) {
+                    }
+                }
+            } catch (Exception e) {
+                try {
+                    java.lang.reflect.Method gm = clusterCacheInvalidationRequest
+                    .getClass()
+                    .getMethod("getCacheManagerName");
+                    Object cmn = gm.invoke(clusterCacheInvalidationRequest);
+                    if (cmn != null) {
+                        dto.setCacheManagerName(cmn.toString());
+                    }
+                } catch (Exception ignored) {
+                }
+                try {
+                    java.lang.reflect.Method gn = clusterCacheInvalidationRequest.getClass().getMethod("getCacheName");
+                    Object cn = gn.invoke(clusterCacheInvalidationRequest);
+                    if (cn != null) {
+                        dto.setCacheName(cn.toString());
+                    }
+                } catch (Exception ignored) {
+                }
+                try {
+                    java.lang.reflect.Method gk = clusterCacheInvalidationRequest.getClass().getMethod("getCacheKey");
+                    Object ck = gk.invoke(clusterCacheInvalidationRequest);
+                    if (ck != null) {
+                        dto.setCacheKeyBase64(serializeToBase64(ck));
+                    }
+                } catch (Exception ignored) {
+                }
+            }
+
+            String jsonMessage = OBJECT_MAPPER.writeValueAsString(dto);
+            TextMessage message = session.createTextMessage(jsonMessage);
             if (StringUtils.isNotBlank(JMSUtils.getProducerName())) {
                 message.setStringProperty(JMSUtils.SENDER, JMSUtils.getProducerName());
             }
             producer.send(message);
         } catch (JMSException e) {
             log.error("Something went wrong with JMS producer connection." + e);
+        } catch (JsonProcessingException e) {
+            log.error("Failed to serialize cache invalidation message for cache '"
+                    + clusterCacheInvalidationRequest.getCacheInfo().getCacheName() + "' with key '"
+                    + clusterCacheInvalidationRequest.getCacheInfo().getCacheKey() + "'.", e);
         }
     }
 
@@ -274,5 +389,13 @@ public class JMSProducer implements CacheEntryRemovedListener, CacheEntryUpdated
             log.debug("JMS session is expired or invalid.");
             return false;
         }
+    }
+
+    private static String serializeToBase64(Object obj) throws IOException {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(bos);
+        oos.writeObject(obj);
+        oos.flush();
+        return Base64.getEncoder().encodeToString(bos.toByteArray());
     }
 }

--- a/components/org.wso2.carbon.cache.sync.jms.manager/src/main/java/org/wso2/carbon/cache/sync/jms/manager/JMSProducer.java
+++ b/components/org.wso2.carbon.cache.sync.jms.manager/src/main/java/org/wso2/carbon/cache/sync/jms/manager/JMSProducer.java
@@ -189,103 +189,12 @@ public class JMSProducer implements CacheEntryRemovedListener, CacheEntryUpdated
             // subclass fields to Jackson; building our own DTO avoids missing values.
             CacheInvalidationMessageDTO dto = new CacheInvalidationMessageDTO();
 
-            try {
-                java.lang.reflect.Method m = clusterCacheInvalidationRequest.getClass().getMethod("getUuid");
-                Object uuid = m.invoke(clusterCacheInvalidationRequest);
-                if (uuid != null) {
-                    dto.setUuid(uuid.toString());
-                }
-            } catch (Exception ignored) {
-            }
-
-            try {
-                java.lang.reflect.Method m = clusterCacheInvalidationRequest.getClass().getMethod("getTimestamp");
-                Object ts = m.invoke(clusterCacheInvalidationRequest);
-                if (ts instanceof Number) {
-                    dto.setTimestamp(((Number) ts).longValue());
-                }
-            } catch (Exception ignored) {
-            }
-
-            try {
-                java.lang.reflect.Method m = clusterCacheInvalidationRequest.getClass().getMethod("getTenantDomain");
-                Object td = m.invoke(clusterCacheInvalidationRequest);
-                if (td != null) {
-                    dto.setTenantDomain(td.toString());
-                }
-            } catch (Exception ignored) {
-            }
-
-            try {
-                java.lang.reflect.Method m = clusterCacheInvalidationRequest.getClass().getMethod("getTenantId");
-                Object tid = m.invoke(clusterCacheInvalidationRequest);
-                if (tid instanceof Number) {
-                    dto.setTenantId(((Number) tid).intValue());
-                }
-            } catch (Exception ignored) {
-            }
-
-            // Try to extract cache info either from a nested CacheInfo object or
-            // from direct getters on the request.
-            try {
-                java.lang.reflect.Method getCacheInfo = clusterCacheInvalidationRequest
-                .getClass()
-                .getMethod("getCacheInfo");
-                Object cacheInfo = getCacheInfo.invoke(clusterCacheInvalidationRequest);
-                if (cacheInfo != null) {
-                    try {
-                        java.lang.reflect.Method gm = cacheInfo.getClass().getMethod("getCacheManagerName");
-                        Object cmn = gm.invoke(cacheInfo);
-                        if (cmn != null) {
-                            dto.setCacheManagerName(cmn.toString());
-                        }
-                    } catch (Exception ignored) {
-                    }
-                    try {
-                        java.lang.reflect.Method gn = cacheInfo.getClass().getMethod("getCacheName");
-                        Object cn = gn.invoke(cacheInfo);
-                        if (cn != null) {
-                            dto.setCacheName(cn.toString());
-                        }
-                    } catch (Exception ignored) {
-                    }
-                    try {
-                        java.lang.reflect.Method gk = cacheInfo.getClass().getMethod("getCacheKey");
-                        Object ck = gk.invoke(cacheInfo);
-                        if (ck != null) {
-                            dto.setCacheKeyBase64(serializeToBase64(ck));
-                        }
-                    } catch (Exception ignored) {
-                    }
-                }
-            } catch (Exception e) {
-                try {
-                    java.lang.reflect.Method gm = clusterCacheInvalidationRequest
-                    .getClass()
-                    .getMethod("getCacheManagerName");
-                    Object cmn = gm.invoke(clusterCacheInvalidationRequest);
-                    if (cmn != null) {
-                        dto.setCacheManagerName(cmn.toString());
-                    }
-                } catch (Exception ignored) {
-                }
-                try {
-                    java.lang.reflect.Method gn = clusterCacheInvalidationRequest.getClass().getMethod("getCacheName");
-                    Object cn = gn.invoke(clusterCacheInvalidationRequest);
-                    if (cn != null) {
-                        dto.setCacheName(cn.toString());
-                    }
-                } catch (Exception ignored) {
-                }
-                try {
-                    java.lang.reflect.Method gk = clusterCacheInvalidationRequest.getClass().getMethod("getCacheKey");
-                    Object ck = gk.invoke(clusterCacheInvalidationRequest);
-                    if (ck != null) {
-                        dto.setCacheKeyBase64(serializeToBase64(ck));
-                    }
-                } catch (Exception ignored) {
-                }
-            }
+            dto.setTenantDomain(clusterCacheInvalidationRequest.getTenantDomain());
+            dto.setTenantId(clusterCacheInvalidationRequest.getTenantId());
+            ClusterCacheInvalidationRequest.CacheInfo cacheInfo = clusterCacheInvalidationRequest.getCacheInfo();
+            dto.setCacheManagerName(cacheInfo.getCacheManagerName());
+            dto.setCacheName(cacheInfo.getCacheName());
+            dto.setCacheKeyBase64(serializeToBase64(cacheInfo.getCacheKey()));
 
             String jsonMessage = OBJECT_MAPPER.writeValueAsString(dto);
             TextMessage message = session.createTextMessage(jsonMessage);
@@ -299,6 +208,8 @@ public class JMSProducer implements CacheEntryRemovedListener, CacheEntryUpdated
             log.error("Failed to serialize cache invalidation message for cache '"
                     + clusterCacheInvalidationRequest.getCacheInfo().getCacheName() + "' with key '"
                     + clusterCacheInvalidationRequest.getCacheInfo().getCacheKey() + "'.", e);
+        } catch (IOException e) {
+            log.error("" + e);
         }
     }
 

--- a/components/org.wso2.carbon.cache.sync.jms.manager/src/main/java/org/wso2/carbon/cache/sync/jms/manager/JMSProducer.java
+++ b/components/org.wso2.carbon.cache.sync.jms.manager/src/main/java/org/wso2/carbon/cache/sync/jms/manager/JMSProducer.java
@@ -202,10 +202,8 @@ public class JMSProducer implements CacheEntryRemovedListener, CacheEntryUpdated
             } else {
                 // Log a clear error if cache key is not serializable
                 // invalidation will be skipped for this key
-                log.error("Cache key is not Serializable. CacheManager: "
-                        + cacheInfo.getCacheManagerName()
-                        + ", Cache: " + cacheInfo.getCacheName()
-                        + ", Key class: " + cacheKey.getClass().getName());
+                log.error("Cache key is not Serializable. CacheManager: " + cacheInfo.getCacheManagerName() +
+                        ", Cache: " + cacheInfo.getCacheName() + ", Key class: " + cacheKey.getClass().getName());
                 dto.setCacheKeyBase64(null);
             }
 
@@ -315,7 +313,7 @@ public class JMSProducer implements CacheEntryRemovedListener, CacheEntryUpdated
         }
     }
 
-    protected static String serializeToBase64(Object object) throws IOException {
+    private static String serializeToBase64(Object object) throws IOException {
 
         try (ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
              ObjectOutputStream objectOutputStream = new ObjectOutputStream(byteArrayOutputStream)) {

--- a/components/org.wso2.carbon.cache.sync.jms.manager/src/main/java/org/wso2/carbon/cache/sync/jms/manager/internal/CacheInvalidationMessageDTO.java
+++ b/components/org.wso2.carbon.cache.sync.jms.manager/src/main/java/org/wso2/carbon/cache/sync/jms/manager/internal/CacheInvalidationMessageDTO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.carbon.cache.sync.jms.manager/src/main/java/org/wso2/carbon/cache/sync/jms/manager/internal/CacheInvalidationMessageDTO.java
+++ b/components/org.wso2.carbon.cache.sync.jms.manager/src/main/java/org/wso2/carbon/cache/sync/jms/manager/internal/CacheInvalidationMessageDTO.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.cache.sync.jms.manager.internal;
+
+/**
+ * Data Transfer Object (DTO) representing a cache invalidation message
+ * to be sent across clusters via JMS.
+ * <p>
+ * This class is used to serialize essential information from a
+ * {@link org.wso2.carbon.caching.impl.clustering.ClusterCacheInvalidationRequest}
+ * into a stable format, ensuring that all necessary fields are propagated
+ * even when subclass fields are not directly exposed.
+ * </p>
+ */
+public class CacheInvalidationMessageDTO {
+
+    private String uuid;
+    private long timestamp;
+    private String tenantDomain;
+    private int tenantId;
+
+    private String cacheManagerName;
+    private String cacheName;
+    private String cacheKeyBase64;
+
+    public CacheInvalidationMessageDTO() {
+    }
+
+
+    public String getUuid() {
+        return uuid;
+    }
+
+    public void setUuid(String uuid) {
+        this.uuid = uuid;
+    }
+
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(long timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public String getTenantDomain() {
+        return tenantDomain;
+    }
+
+    public void setTenantDomain(String tenantDomain) {
+        this.tenantDomain = tenantDomain;
+    }
+
+    public int getTenantId() {
+        return tenantId;
+    }
+
+    public void setTenantId(int tenantId) {
+        this.tenantId = tenantId;
+    }
+
+    public String getCacheManagerName() {
+        return cacheManagerName;
+    }
+
+    public void setCacheManagerName(String cacheManagerName) {
+        this.cacheManagerName = cacheManagerName;
+    }
+
+    public String getCacheName() {
+        return cacheName;
+    }
+
+    public void setCacheName(String cacheName) {
+        this.cacheName = cacheName;
+    }
+
+    public String getCacheKeyBase64() {
+        return this.cacheKeyBase64;
+    }
+
+    public void setCacheKeyBase64(String cacheKeyBase64) {
+        this.cacheKeyBase64 = cacheKeyBase64;
+    }
+}

--- a/components/org.wso2.carbon.cache.sync.jms.manager/src/main/java/org/wso2/carbon/cache/sync/jms/manager/internal/CacheInvalidationMessageDTO.java
+++ b/components/org.wso2.carbon.cache.sync.jms.manager/src/main/java/org/wso2/carbon/cache/sync/jms/manager/internal/CacheInvalidationMessageDTO.java
@@ -19,20 +19,20 @@
 package org.wso2.carbon.cache.sync.jms.manager.internal;
 
 /**
- * Data Transfer Object (DTO) representing a cache invalidation message
- * to be sent across clusters via JMS.
+ * Data Transfer Object (DTO) that represents a cache invalidation message
+ * exchanged across cluster nodes via JMS.
  * <p>
- * This class is used to serialize essential information from a
+ * This DTO is used to serialize and transport the essential cache
+ * invalidation details extracted from
  * {@link org.wso2.carbon.caching.impl.clustering.ClusterCacheInvalidationRequest}
- * into a stable format, ensuring that all necessary fields are propagated
- * even when subclass fields are not directly exposed.
+ * into a stable and decoupled format. This ensures that all required
+ * information is propagated correctly across the cluster.
  * </p>
  */
 public class CacheInvalidationMessageDTO {
 
     private String tenantDomain;
     private int tenantId;
-
     private String cacheManagerName;
     private String cacheName;
     private String cacheKeyBase64;

--- a/components/org.wso2.carbon.cache.sync.jms.manager/src/main/java/org/wso2/carbon/cache/sync/jms/manager/internal/CacheInvalidationMessageDTO.java
+++ b/components/org.wso2.carbon.cache.sync.jms.manager/src/main/java/org/wso2/carbon/cache/sync/jms/manager/internal/CacheInvalidationMessageDTO.java
@@ -30,8 +30,6 @@ package org.wso2.carbon.cache.sync.jms.manager.internal;
  */
 public class CacheInvalidationMessageDTO {
 
-    private String uuid;
-    private long timestamp;
     private String tenantDomain;
     private int tenantId;
 
@@ -40,23 +38,6 @@ public class CacheInvalidationMessageDTO {
     private String cacheKeyBase64;
 
     public CacheInvalidationMessageDTO() {
-    }
-
-
-    public String getUuid() {
-        return uuid;
-    }
-
-    public void setUuid(String uuid) {
-        this.uuid = uuid;
-    }
-
-    public long getTimestamp() {
-        return timestamp;
-    }
-
-    public void setTimestamp(long timestamp) {
-        this.timestamp = timestamp;
     }
 
     public String getTenantDomain() {

--- a/components/org.wso2.carbon.cache.sync.jms.manager/src/test/java/org/wso2/carbon/cache/sync/jms/manager/JMSConsumerTest.java
+++ b/components/org.wso2.carbon.cache.sync.jms.manager/src/test/java/org/wso2/carbon/cache/sync/jms/manager/JMSConsumerTest.java
@@ -17,6 +17,7 @@
  */
 package org.wso2.carbon.cache.sync.jms.manager;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.MockitoAnnotations;
@@ -24,9 +25,11 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import org.wso2.carbon.base.CarbonBaseConstants;
+import org.wso2.carbon.cache.sync.jms.manager.internal.CacheInvalidationMessageDTO;
 import org.wso2.carbon.caching.impl.CacheImpl;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 
+import java.io.IOException;
 import java.nio.file.Paths;
 
 import javax.cache.CacheManager;
@@ -110,10 +113,17 @@ public class JMSConsumerTest {
     }
 
     @Test
-    public void testInvalidateCache() {
+    public void testInvalidateCache() throws IOException {
 
-        String message = "ClusterCacheInvalidationRequest{tenantId=1, tenantDomain='example.com', messageId=123, " +
-                "cacheManager=myCacheManager, cache=myCache, cacheKey=myKey}";
+        // Create DTO
+        CacheInvalidationMessageDTO dto = new CacheInvalidationMessageDTO();
+        dto.setTenantId(1);
+        dto.setTenantDomain("example.com");
+        dto.setCacheManagerName("myCacheManager");
+        dto.setCacheName("myCache");
+        dto.setCacheKeyBase64(JMSProducer.serializeToBase64("myKey"));
+
+        String message = new ObjectMapper().writeValueAsString(dto);
 
         try (MockedStatic<PrivilegedCarbonContext> mockedPrivilegedCarbonContext =
                      mockStatic(PrivilegedCarbonContext.class);

--- a/components/org.wso2.carbon.cache.sync.jms.manager/src/test/java/org/wso2/carbon/cache/sync/jms/manager/JMSConsumerTest.java
+++ b/components/org.wso2.carbon.cache.sync.jms.manager/src/test/java/org/wso2/carbon/cache/sync/jms/manager/JMSConsumerTest.java
@@ -17,7 +17,6 @@
  */
 package org.wso2.carbon.cache.sync.jms.manager;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.MockitoAnnotations;
@@ -25,7 +24,6 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import org.wso2.carbon.base.CarbonBaseConstants;
-import org.wso2.carbon.cache.sync.jms.manager.internal.CacheInvalidationMessageDTO;
 import org.wso2.carbon.caching.impl.CacheImpl;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 
@@ -115,15 +113,13 @@ public class JMSConsumerTest {
     @Test
     public void testInvalidateCache() throws IOException {
 
-        // Create DTO
-        CacheInvalidationMessageDTO dto = new CacheInvalidationMessageDTO();
-        dto.setTenantId(1);
-        dto.setTenantDomain("example.com");
-        dto.setCacheManagerName("myCacheManager");
-        dto.setCacheName("myCache");
-        dto.setCacheKeyBase64(JMSProducer.serializeToBase64("myKey"));
-
-        String message = new ObjectMapper().writeValueAsString(dto);
+        String message = "{"
+            + "\"tenantDomain\":\"example.com\","
+            + "\"tenantId\":1,"
+            + "\"cacheManagerName\":\"myCacheManager\","
+            + "\"cacheName\":\"myCache\","
+            + "\"cacheKeyBase64\":\"rO0ABXQABW15S2V5\""
+            + "}";
 
         try (MockedStatic<PrivilegedCarbonContext> mockedPrivilegedCarbonContext =
                      mockStatic(PrivilegedCarbonContext.class);

--- a/pom.xml
+++ b/pom.xml
@@ -323,7 +323,7 @@
         <log4j-api.version>2.14.1</log4j-api.version>
         <carbon.p2.plugin.version>5.1.2</carbon.p2.plugin.version>
         <commons-lang.version>2.6.0.wso2v1</commons-lang.version>
-        <javax.cache.wso2.version>4.9.26</javax.cache.wso2.version>
+        <javax.cache.wso2.version>4.9.24</javax.cache.wso2.version>
         <javax.jms-api.version>2.0.1</javax.jms-api.version>
         <amqp-client.version>5.15.0</amqp-client.version>
         <rabbitmq-jms.version>2.2.0</rabbitmq-jms.version>

--- a/pom.xml
+++ b/pom.xml
@@ -323,7 +323,7 @@
         <log4j-api.version>2.14.1</log4j-api.version>
         <carbon.p2.plugin.version>5.1.2</carbon.p2.plugin.version>
         <commons-lang.version>2.6.0.wso2v1</commons-lang.version>
-        <javax.cache.wso2.version>4.9.0.109</javax.cache.wso2.version>
+        <javax.cache.wso2.version>4.10.120</javax.cache.wso2.version>
         <javax.jms-api.version>2.0.1</javax.jms-api.version>
         <amqp-client.version>5.15.0</amqp-client.version>
         <rabbitmq-jms.version>2.2.0</rabbitmq-jms.version>

--- a/pom.xml
+++ b/pom.xml
@@ -323,7 +323,7 @@
         <log4j-api.version>2.14.1</log4j-api.version>
         <carbon.p2.plugin.version>5.1.2</carbon.p2.plugin.version>
         <commons-lang.version>2.6.0.wso2v1</commons-lang.version>
-        <javax.cache.wso2.version>4.9.24</javax.cache.wso2.version>
+        <javax.cache.wso2.version>4.9.0.109</javax.cache.wso2.version>
         <javax.jms-api.version>2.0.1</javax.jms-api.version>
         <amqp-client.version>5.15.0</amqp-client.version>
         <rabbitmq-jms.version>2.2.0</rabbitmq-jms.version>

--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,16 @@
                 <scope>test</scope>
                 <version>${testng.version}</version>
             </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>${com.fasterxml.jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${jackson-databind.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -313,10 +323,12 @@
         <log4j-api.version>2.14.1</log4j-api.version>
         <carbon.p2.plugin.version>5.1.2</carbon.p2.plugin.version>
         <commons-lang.version>2.6.0.wso2v1</commons-lang.version>
-        <javax.cache.wso2.version>4.9.24</javax.cache.wso2.version>
+        <javax.cache.wso2.version>4.9.26</javax.cache.wso2.version>
         <javax.jms-api.version>2.0.1</javax.jms-api.version>
         <amqp-client.version>5.15.0</amqp-client.version>
         <rabbitmq-jms.version>2.2.0</rabbitmq-jms.version>
+        <com.fasterxml.jackson.version>2.13.2</com.fasterxml.jackson.version>
+        <jackson-databind.version>2.13.2.1</jackson-databind.version>
 
         <!--Maven Plugin Version-->
         <maven.scr.plugin.version>1.22.0</maven.scr.plugin.version>


### PR DESCRIPTION
## Purpose

Cache invalidation messages sent over JMS were unable to correctly invalidate caches that use **object-based cache keys** (for example, OAuth-related caches).
The existing implementation relied on string-based representations (and later regex parsing), which caused loss of type information and resulted in cache misses on the consumer side.

This PR introduces a deterministic and cluster-safe way of transporting cache keys without adding new dependencies to the carbon-kernel.

Related Issue: https://github.com/wso2-enterprise/wso2-iam-internal/issues/5437

---

## Goals

* Ensure cache invalidation works correctly for caches that use **non-String (object) cache keys**
* Preserve the **exact cache key type** across JMS-based cluster communication
* Maintain compatibility with existing JMS-only and JMS + Hazelcast (hybrid) modes

---

## Approach

* Introduced a stable DTO (`CacheInvalidationMessageDTO`) for JMS message transport.
* Explicitly serialize the cache key using Java serialization and encode it as Base64 on the producer side.
* Deserialize the Base64 payload back to the original cache key object on the consumer side.
* Replaced regex-based message parsing with JSON-based deserialization using the DTO.
* Ensured that cache invalidation logic operates on the **actual cache key object**, allowing `removeLocal(key)` to work reliably.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> N/A

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.